### PR TITLE
Fixing password handling

### DIFF
--- a/Configure-cac-agent-for-Linux.md
+++ b/Configure-cac-agent-for-Linux.md
@@ -27,9 +27,9 @@ Specify CAC middlware by creating:
 	library=/usr/lib64/pkcs11/libcoolkeypk11.so
 	name="CAC Key"
 
-... replacing ```/usr/lib64/pkcs11/libcoolkeypk11.so``` with your chosen middleware.
-The [previously reference guide](Setting-Up-CAC-Smart-Card-in-Ubuntu-16.md) enumerates these options:
+... replacing `/usr/lib64/pkcs11/libcoolkeypk11.so` with your chosen middleware.
+The [previously referenced guide](Setting-Up-PKCS11-CAC-Drivers-in-Ubuntu-16.md) enumerates these options:
 
-* (for original coolkey): ```/usr/lib/pkcs11/libcoolkeypk11.so```
-* (for coolkey with 64-bit fix): ```/usr/lib64/pkcs11/libcoolkeypk11.so```
-* (for opensc): ```/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so```
+* (for original coolkey): `/usr/lib/pkcs11/libcoolkeypk11.so`
+* (for coolkey with 64-bit fix): `/usr/lib64/pkcs11/libcoolkeypk11.so`
+* (for opensc): `/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so`

--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ Other Notes
 ----------------
 
 * [Text-Only Mode](Text-Only-Mode.md) (instead of a the graphical interface)
+* [Storing Username/Password](Storing-Username-Password.md) (skipping prompt)
 * [Setting Up PKCS11 CAC Drivers in Ubuntu 16](Setting-Up-PKCS11-CAC-Drivers-in-Ubuntu-16.md)
 * [Using cac-agent with Older JGit Releases](Using-cac-agent-with-Older-JGit-Releases.md)

--- a/Storing-Username-Password.md
+++ b/Storing-Username-Password.md
@@ -1,0 +1,34 @@
+Storing Username/Password
+================
+
+Plaintext Username/Password
+----------------
+
+If you want to store your username/password so that you don't
+have to enter them on every git command, simply add them to
+`~/.moesol/cac-agent/agent.properties` (or `%USERPROFILE%\.moesol\cac-agent\agent.properties` on Windows):
+
+	user: XXXX
+	password: XXXX
+
+
+Encrypted Username/Password
+----------------
+
+If you're into security theater, you can encrypt your git password using
+a "master" password. This ensures that your git password isn't
+"stored in plain text", but it is stored next
+to the master password, which is in plain text. (High-fives!)
+
+To generate the encrypted form of your password, run:
+
+	cac-git --cac-agent-encrypt
+
+Then enter your git password and a new master password.
+
+Then add your encrypted git password and master password to `agent.properties`:
+
+	user: XXXX
+	password: <output-of-command>
+	master: XXXX
+

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
-							<Premain-Class>com.moesol.url.CacHookingAgent</Premain-Class>
+							<Premain-Class>org.eclipse.jgit.pgm.CacHookingAgent</Premain-Class>
 							<Can-Redefine-Classes>false</Can-Redefine-Classes>
 							<Can-Retransform-Classes>false</Can-Retransform-Classes>
 							<Git-Commit-Id>${mvngit.commit.id}</Git-Commit-Id>
@@ -92,7 +92,7 @@
 					</descriptorRefs>
 					<archive>
 						<manifest>
-							<mainClass>com.moesol.jgit.JgitCac</mainClass>
+							<mainClass>org.eclipse.jgit.pgm.JgitCac</mainClass>
 						</manifest>
 					</archive>
 				</configuration>

--- a/src/main/java/com/moesol/cac/agent/Config.java
+++ b/src/main/java/com/moesol/cac/agent/Config.java
@@ -4,16 +4,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.security.Key;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.Properties;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.crypto.Cipher;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.spec.PBEParameterSpec;
 
 import org.jasypt.util.text.BasicTextEncryptor;
 
@@ -75,11 +67,27 @@ public class Config {
 		this.master = master;
 	}
 
-
-	public String decryptPass() {
+	/**
+	 * Returns the git password, decrypting if necessary.
+	 */
+	public String getDecryptedPass() {
+		// If no master defined, we presume password is plain text
+		if (this.master == null) {
+			return this.encryptedPassword;
+		}
 		BasicTextEncryptor bte = new BasicTextEncryptor();
-		bte.setPassword(getMaster());
-		return bte.decrypt(getPass());
+		bte.setPassword(this.master);
+		return bte.decrypt(this.encryptedPassword);
+	}
+
+	/**
+	 * Returns an encrypted version of the git password, using the provided master
+	 * password.
+	 */
+	public static String encryptPass(String masterPass, String pass) {
+		BasicTextEncryptor bte = new BasicTextEncryptor();
+		bte.setPassword(masterPass);
+		return bte.encrypt(pass);
 	}
 
 	public static Config loadFromUserHome() {


### PR DESCRIPTION
* Updated credentials mechanism to work the same way for both "git clone" and "git fetch"
* Fixed a bug in user/pass handling that was breaking "git fetch"
* Added support for using a non-encrypted password (simpler to setup)
* Added "--cac-agent-encrypt" command for generating an encrypted password
* Added documentation for storing username/password
