### PR TITLE
Feature/profiles

### DIFF
--- a/Profile-Support.md
+++ b/Profile-Support.md
@@ -1,0 +1,18 @@
+Profile Support
+================
+
+If you need to have different configurations for different servers, then profile support may help.
+Without specifying any profile the configuration and truststore files are searched for under your
+home folder in `.moesol/cac-agent`
+
+If you need a different configuration you can make `cac-agent` search in a sub-directory
+by specifying a "profile" name via a system property `com.moesol.agent.profile`.
+For example, if you have a different truststore, username, and password for the
+foobar server, you can add `-Dcom.moesol.agent.profile=foobar` to the java options
+and `cac-agent` will use `~/.moesol/cac-agent/foobar` as the folder for these files:
+
+```
+agent.properties
+pkcs11.cfg
+truststore.jks
+```

--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ Other Notes
 * [Text-Only Mode](Text-Only-Mode.md) (instead of a the graphical interface)
 * [Storing Username/Password](Storing-Username-Password.md) (skipping prompt)
 * [Setting Up PKCS11 CAC Drivers in Ubuntu 16](Setting-Up-PKCS11-CAC-Drivers-in-Ubuntu-16.md)
+* [Profile Support](Profile-Support.md) 
 * [Using cac-agent with Older JGit Releases](Using-cac-agent-with-Older-JGit-Releases.md)

--- a/Setting-Up-PKCS11-CAC-Drivers-in-Ubuntu-16.md
+++ b/Setting-Up-PKCS11-CAC-Drivers-in-Ubuntu-16.md
@@ -31,7 +31,7 @@ OpenSC
 * Unstable in firefox/chrome, but generally stable with command line tools
 * Works with all government-issued and retail CACs we've tried
 
-NOTE: You can install both middlwares and selectively use as desired.
+NOTE: You can install both middle-wares and selectively use as desired.
 
 
 Install Middlware
@@ -103,3 +103,12 @@ Verify the module was added:
 
 	modutil -dbdir sql:.pki/nssdb/ -list
 
+## Slots
+
+Some devices may need the slot defined. For example, Yubikey's may need to use `slotListIndex=1`
+
+```
+library=/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so
+name="Yubikey"
+slotListIndex=1 
+```

--- a/src/main/java/com/moesol/cac/agent/CacHookingAgent.java
+++ b/src/main/java/com/moesol/cac/agent/CacHookingAgent.java
@@ -6,7 +6,6 @@ import java.lang.instrument.Instrumentation;
 import com.moesol.cac.agent.selector.AbstractSelectorKeyManager;
 
 public class CacHookingAgent {
-	public static final String CAC_AGENT_DIR = ".moesol/cac-agent";
 	public static boolean DEBUG = false;
 	public static String CONTEXT = "TLS";
 
@@ -22,7 +21,7 @@ public class CacHookingAgent {
 	}
 
 	public static void maybeSetTrustFile() {
-		File trustStoreFile = new File(System.getProperty("user.home"), CAC_AGENT_DIR + "/truststore.jks");
+		File trustStoreFile = new File(Config.computeProfileFolder(), "truststore.jks"); 
 		if (trustStoreFile.canRead()) {
 			System.out.println("Using trustore " + trustStoreFile.getPath());
 			System.setProperty("javax.net.ssl.trustStoreType", "JKS");

--- a/src/main/java/com/moesol/cac/agent/Config.java
+++ b/src/main/java/com/moesol/cac/agent/Config.java
@@ -11,6 +11,9 @@ import org.jasypt.util.text.BasicTextEncryptor;
 
 public class Config {
 	private static final Logger LOGGER = Logger.getLogger(Config.class.getName());
+	private static final String CAC_AGENT_DIR = ".moesol/cac-agent";
+	private static final String COM_MOESOL_AGENT_PROFILE = "com.moesol.agent.profile";
+	private static final String AGENT_PROPERTIES = "agent.properties";
 
 	private boolean useWindowsTrust = true;
 	private String defaultCertificateName = null;
@@ -96,15 +99,15 @@ public class Config {
 			return new Config();
 		}
 		try {
-			return doLoadProperties(userHome);
+			return doLoadProperties();
 		} catch (IOException e) {
 			e.printStackTrace(System.err);
 			return new Config();
 		}
 	}
 
-	private static Config doLoadProperties(String userHome) throws IOException, FileNotFoundException {
-		File file = new File(userHome, CacHookingAgent.CAC_AGENT_DIR + "/agent.properties");
+	private static Config doLoadProperties() throws IOException, FileNotFoundException {
+		File file = computeAgentPropertiesFile();
 		System.out.printf("Loading properties from %s%n", file);
 		if (!file.exists()) {
 			return new Config();
@@ -122,6 +125,20 @@ public class Config {
 			result.setMaster(p.getProperty("master"));
 			return result;
 		}
+	}
+	
+	public static File computeProfileFolder() {
+		String userHome = System.getProperty("user.home");
+		String profile = System.getProperty(COM_MOESOL_AGENT_PROFILE, "");
+		if (profile.isEmpty()) {
+			return new File(userHome, CAC_AGENT_DIR);
+		} else {
+			return new File(new File(userHome, CAC_AGENT_DIR), profile);
+		}
+	}
+
+	private static File computeAgentPropertiesFile() {
+		return new File(computeProfileFolder(), AGENT_PROPERTIES);
 	}
 
 }

--- a/src/main/java/com/moesol/cac/agent/selector/Pkcs11SelectorKeyManager.java
+++ b/src/main/java/com/moesol/cac/agent/selector/Pkcs11SelectorKeyManager.java
@@ -13,7 +13,7 @@ import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.swing.JOptionPane;
 
-import com.moesol.cac.agent.CacHookingAgent;
+import com.moesol.cac.agent.Config;
 
 public class Pkcs11SelectorKeyManager extends AbstractSelectorKeyManager {
 
@@ -55,9 +55,8 @@ public class Pkcs11SelectorKeyManager extends AbstractSelectorKeyManager {
 	private void setUpProvider() {
 		chooser.showBusy("Initializing PKCS#11...");
 		try {
-			String home = System.getProperty("user.home");
-			String configName = home + "/" + CacHookingAgent.CAC_AGENT_DIR + "/pkcs11.cfg";
-			File configFile = new File(configName);
+			File configFile = new File(Config.computeProfileFolder(), "pkcs11.cfg");
+			String configName = configFile.getAbsolutePath();
 			if (configFile.exists()) {
 				provider = new sun.security.pkcs11.SunPKCS11(configName);
 				Security.addProvider(provider);	

--- a/src/main/java/com/moesol/jgit/HookedHttpClientConnectionFactory.java
+++ b/src/main/java/com/moesol/jgit/HookedHttpClientConnectionFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.jgit.transport.http.HttpConnection;
 import org.eclipse.jgit.transport.http.apache.HttpClientConnection;
 import org.eclipse.jgit.transport.http.apache.HttpClientConnectionFactory;
 
-import com.moesol.cac.agent.CacHookingAgent;
 import com.moesol.cac.agent.Config;
 import com.moesol.cac.agent.selector.AbstractSelectorKeyManager;
 
@@ -77,7 +76,7 @@ public class HookedHttpClientConnectionFactory extends HttpClientConnectionFacto
 	}
 	
 	private KeyStore loadTrustStore() throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
-		File trustStoreFile = new File(System.getProperty("user.home"), CacHookingAgent.CAC_AGENT_DIR + "/truststore.jks");
+		File trustStoreFile = new File(Config.computeProfileFolder(), "truststore.jks");
 		if (trustStoreFile.canRead()) {
 			System.out.println("Reading trustore " + trustStoreFile.getPath());
 		} else {


### PR DESCRIPTION
Now that we have two CAC/PIV protected sites to deal with, I need a different configuration for each. These changes make switching between them easier. They also add to the documentation information about "slots" in the pkcs11.cfg file.