### PR TITLE
Adds com.moesol.agent.config to specify the full path to config dir.

### DIFF
--- a/Profile-Support.md
+++ b/Profile-Support.md
@@ -16,3 +16,25 @@ agent.properties
 pkcs11.cfg
 truststore.jks
 ```
+
+Configuration Directory Support
+===============================
+
+If you would rather put the configuration directory into a specific directory instead
+of having it under your home folder then you can give the absolute path to the configuration
+directory using the Java system property `com.moesol.agent.config`. For example,
+
+```
+-Dcom.moesol.agent.config=/home/user/jgit-cac/configuration
+```
+
+This form is useful if you have a configuration with a `pkcs11.cfg` and a `truststore.jks` that you would like
+to zip up and share. 
+
+> Note, be sure to remove your saved credentials in `agent.properties` before you share it.
+
+Option Precedence
+=================
+
+If both `com.moesol.agent.config` and `com.moesol.agent.profile` are specified `com.moesol.agent.config`,
+then `com.moesol.agent.config` takes precedence and `com.moesol.agent.profile` is ignored.

--- a/src/main/java/com/moesol/cac/agent/Config.java
+++ b/src/main/java/com/moesol/cac/agent/Config.java
@@ -13,6 +13,7 @@ public class Config {
 	private static final Logger LOGGER = Logger.getLogger(Config.class.getName());
 	private static final String CAC_AGENT_DIR = ".moesol/cac-agent";
 	private static final String COM_MOESOL_AGENT_PROFILE = "com.moesol.agent.profile";
+	private static final String COM_MOESOL_AGENT_CONFIG  = "com.moesol.agent.config";
 	private static final String AGENT_PROPERTIES = "agent.properties";
 
 	private boolean useWindowsTrust = true;
@@ -129,12 +130,16 @@ public class Config {
 	
 	public static File computeProfileFolder() {
 		String userHome = System.getProperty("user.home");
+		String configuration  = System.getProperty(COM_MOESOL_AGENT_CONFIG, "");
 		String profile = System.getProperty(COM_MOESOL_AGENT_PROFILE, "");
-		if (profile.isEmpty()) {
-			return new File(userHome, CAC_AGENT_DIR);
-		} else {
-			return new File(new File(userHome, CAC_AGENT_DIR), profile);
+		
+		if (!configuration.isEmpty()) {
+			return new File(configuration);
 		}
+		if (!profile.isEmpty()) {
+			return new File(new File(userHome, CAC_AGENT_DIR), profile);
+		} 
+		return new File(userHome, CAC_AGENT_DIR);
 	}
 
 	private static File computeAgentPropertiesFile() {


### PR DESCRIPTION
I wanted to zip of a folder that was pre-configured for one of our servers. This option let's me include the trustore in the zip. Otherwise, I have to have a second .zip for .moesol folder.