### PR TITLE
Feature/better default cert name error message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,5 +39,5 @@ jobs:
             find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
           when: always
       - store_test_results:
-        path: ~/junit
+          path: ~/junit
       - run: mvn -P circleci integration-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,16 +21,16 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "pom.xml" }}
+          - v2-dependencies-{{ checksum "pom.xml" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v2-dependencies-
 
       - run: mvn dependency:go-offline
 
       - save_cache:
           paths:
             - ~/.m2
-          key: v1-dependencies-{{ checksum "pom.xml" }}
+          key: v2-dependencies-{{ checksum "pom.xml" }}
 
       - run:
           name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,13 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
-        
-      # run tests!
+
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+        path: ~/junit
       - run: mvn -P circleci integration-test

--- a/Profile-Support.md
+++ b/Profile-Support.md
@@ -16,3 +16,25 @@ agent.properties
 pkcs11.cfg
 truststore.jks
 ```
+
+Configuration Directory Support
+===============================
+
+If you would rather put the configuration directory into a specific directory instead
+of having it under your home folder then you can give the absolute path to the configuration
+directory using the Java system property `com.moesol.agent.config`. For example,
+
+```
+-Dcom.moesol.agent.config=/home/user/jgit-cac/configuration
+```
+
+This form is useful if you have a configuration with a `pkcs11.cfg` and a `truststore.jks` that you would like
+to zip up and share. 
+
+> Note, be sure to remove your saved credentials in `agent.properties` before you share it.
+
+Option Precedence
+=================
+
+If both `com.moesol.agent.config` and `com.moesol.agent.profile` are specified `com.moesol.agent.config`,
+then `com.moesol.agent.config` takes precedence and `com.moesol.agent.profile` is ignored.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ to use.
 * ```cac-agent-...-with-dependencies.jar``` executable jar that contains both jgit and cac-agent.
 
 ## Status
+
 [![CircleCI](https://circleci.com/gh/MoebiusSolutions/cac-agent.svg?style=svg)](https://circleci.com/gh/MoebiusSolutions/cac-agent)
 
 Quick Start

--- a/pom.xml
+++ b/pom.xml
@@ -115,11 +115,14 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <version>3.0.0</version>
+			<version>3.0.0</version>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>make-assembly</id>
-                                <phase>none</phase>
+				<phase/>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,13 @@
                             </execution>
                         </executions>
                     </plugin>
+		    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                           <useSystemClassLoader>false</useSystemClassLoader>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/src/main/java/com/moesol/cac/agent/Config.java
+++ b/src/main/java/com/moesol/cac/agent/Config.java
@@ -13,6 +13,7 @@ public class Config {
 	private static final Logger LOGGER = Logger.getLogger(Config.class.getName());
 	private static final String CAC_AGENT_DIR = ".moesol/cac-agent";
 	private static final String COM_MOESOL_AGENT_PROFILE = "com.moesol.agent.profile";
+	private static final String COM_MOESOL_AGENT_CONFIG  = "com.moesol.agent.config";
 	private static final String AGENT_PROPERTIES = "agent.properties";
 
 	private boolean useWindowsTrust = true;
@@ -129,12 +130,16 @@ public class Config {
 	
 	public static File computeProfileFolder() {
 		String userHome = System.getProperty("user.home");
+		String configuration  = System.getProperty(COM_MOESOL_AGENT_CONFIG, "");
 		String profile = System.getProperty(COM_MOESOL_AGENT_PROFILE, "");
-		if (profile.isEmpty()) {
-			return new File(userHome, CAC_AGENT_DIR);
-		} else {
-			return new File(new File(userHome, CAC_AGENT_DIR), profile);
+		
+		if (!configuration.isEmpty()) {
+			return new File(configuration);
 		}
+		if (!profile.isEmpty()) {
+			return new File(new File(userHome, CAC_AGENT_DIR), profile);
+		} 
+		return new File(userHome, CAC_AGENT_DIR);
 	}
 
 	private static File computeAgentPropertiesFile() {


### PR DESCRIPTION
Without this feature, you get a large stack trace with no indication that your default.cert.name property is incorrect.