### PR TITLE
Feature/ssl on client side of relay

### DIFF
--- a/Using-cac-agent-with-ssl-relay.md
+++ b/Using-cac-agent-with-ssl-relay.md
@@ -76,3 +76,23 @@ Similarly, setup your maven repository to use `http://mvn-local:9090/same/path/a
 Now, the next mvn download triggered will be through the relay and prompt you for your PIN
 if it needs it. Any downloads will be downloaded from the CAC protected server after the ssl-relay
 has presented the server with your CAC identity and validated it.
+
+## SSL Server
+
+You can make the `relay` serve SSL sockets by adding `sslRelay` prefixed properties in
+in your `agent.properties`:
+
+```
+sslRelay.docker-local\:8443=cac-required.git.server.org:443
+```
+
+But then, you must configure a SSL key for the server. Below, a self-signed key was configured
+into `certs/me.p12`, with the java default key store password. Adding these options to the `java`
+command when starting the relay configures the key:
+
+```
+  java \
+    -Djavax.net.ssl.keyStoreType=pkcs12 \
+    -Djavax.net.ssl.keyStore=certs/me.p12 \
+    "$@" -jar target/cac-aware-ssl-relay-jar-with-dependencies.jar; 
+```

--- a/src/main/java/com/moesol/cac/agent/Config.java
+++ b/src/main/java/com/moesol/cac/agent/Config.java
@@ -23,6 +23,7 @@ public class Config {
 	private String encryptedPassword = null;
 	private String master = null;
 	private final Map<String, String> relays = new HashMap<>();
+	private final Map<String, String> secureRelays = new HashMap<>();
 
 	public boolean isTty() {
 		return tty;
@@ -98,6 +99,9 @@ public class Config {
 	public Map<String, String> getRelays() {
 		return relays;
 	}
+	public Map<String, String> getSecureRelays() {
+		return secureRelays;
+	}
 
 	public static Config loadFromUserHome() {
 		String userHome = System.getProperty("user.home");
@@ -129,10 +133,16 @@ public class Config {
 			result.setUser(p.getProperty("user"));
 			result.setPass(p.getProperty("pass"));
 			result.setMaster(p.getProperty("master"));
+
 			p.keySet().stream()
 				.map(Object::toString)
 				.filter(Config::isRelayKey)
 				.forEach(k -> result.addRelay(k, p.getProperty(k)));
+				;
+			p.keySet().stream()
+				.map(Object::toString)
+				.filter(Config::isSecuryRelayKey)
+				.forEach(k -> result.addSecureRelay(k, p.getProperty(k)));
 				;
 			return result;
 		}
@@ -143,6 +153,13 @@ public class Config {
 	private void addRelay(String key, String value) {
 		key = key.replaceFirst("^relay\\.", "");
 		relays.put(key, value);
+	}
+	private static boolean isSecuryRelayKey(String key) {
+		return key.startsWith("sslRelay.");
+	}
+	private void addSecureRelay(String key, String value) {
+		key = key.replaceFirst("^sslRelay\\.", "");
+		secureRelays.put(key, value);
 	}
 	
 	public static File computeProfileFolder() {

--- a/src/main/java/com/moesol/cac/agent/selector/AbstractSelectorKeyManager.java
+++ b/src/main/java/com/moesol/cac/agent/selector/AbstractSelectorKeyManager.java
@@ -18,11 +18,9 @@ import java.util.List;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManager;
-import javax.net.ssl.X509ExtendedKeyManager;
-
-
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
 
 import com.moesol.cac.agent.CacHookingAgent;
@@ -32,7 +30,11 @@ import com.moesol.cac.agent.Config;
  * When installed as the default key manager, this class prompts the user as
  * needed to choose a key. The default chooser uses Swing, but a Tty base
  * chooser can be set as a property.
- * 
+ * <p>
+ * Note that this key manager cannot be used if you are creating an SSL/TLS
+ * server because it throws UnsupportedOperationException when asked
+ * to choose a server KeyManager.
+ * <p>
  * @author hastings
  */
 public abstract class AbstractSelectorKeyManager extends X509ExtendedKeyManager	
@@ -100,11 +102,11 @@ public abstract class AbstractSelectorKeyManager extends X509ExtendedKeyManager
 
 	protected abstract KeyStore accessKeyStore() throws Exception;
 
+	// NOTE: Overrides the non-abstract method in base class, tricky.
 	@Override
 	public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
 		return chooseClientAlias(keyType, issuers, (Socket)null);
 	}
-	
 	@Override
 	public synchronized String chooseClientAlias(final String[] keyType, final Principal[] issuers, Socket socket) {
 		if (CacHookingAgent.DEBUG) {
@@ -231,6 +233,11 @@ public abstract class AbstractSelectorKeyManager extends X509ExtendedKeyManager
 		}
 	}
 
+	// NOTE: Overrides the non-abstract method in base class, tricky.
+	@Override
+	public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
+		throw new UnsupportedOperationException("Client manager only");
+	}
 	@Override
 	public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
 		throw new UnsupportedOperationException("Client manager only");
@@ -245,5 +252,5 @@ public abstract class AbstractSelectorKeyManager extends X509ExtendedKeyManager
 		chooser.reportException(e);
 		return new RuntimeException(e);
 	}
-
+	
 }

--- a/src/main/java/com/moesol/cac/relay/SslServerRelay.java
+++ b/src/main/java/com/moesol/cac/relay/SslServerRelay.java
@@ -1,0 +1,114 @@
+package com.moesol.cac.relay;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchProviderException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+import com.moesol.cac.agent.CacHookingAgent;
+
+/**
+ * A java based port forwarder.
+ * It binds to a local bindHost:bindPort and forwards
+ * to the target targetHost:targetPort.
+ * <p>
+ * The incoming connection is SSL/TLS.
+ * The target connection is ALWAYS SSL/TLS.
+ */
+public class SslServerRelay {
+	private static final Logger LOGGER = Logger.getLogger(SslServerRelay.class.getName());
+	private final String bindHost;
+	private final int bindPort;
+	private final String targetHost;
+	private final int targetPort;
+
+	public SslServerRelay(String bindHost, int bindPort, String targetHost, int targetPort) {
+		this.bindHost = bindHost;
+		this.bindPort = bindPort;
+		this.targetHost = targetHost;
+		this.targetPort = targetPort;
+	}
+
+	public void run() {
+		try {
+			run0();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+	public void run0() throws Exception {
+		SSLContext sslContext = SSLContext.getInstance(CacHookingAgent.CONTEXT);
+		sslContext.init(getKeyManagers(), null, new java.security.SecureRandom());
+		SSLServerSocketFactory ssf = sslContext.getServerSocketFactory();
+	    ServerSocket sslListener = ssf.createServerSocket(this.bindPort, 0, Inet4Address.getByName(this.bindHost));
+		
+		try {
+			while (true) {
+				Socket clientSocket = sslListener.accept();
+				relayTo(clientSocket);
+			}
+		} finally {
+			sslListener.close();
+		}
+	}
+
+	private void relayTo(Socket clientSocket) throws UnknownHostException, IOException {
+		Socket serverSocket = SSLSocketFactory.getDefault().createSocket(this.targetHost, this.targetPort);
+		new BiDirectionalRelay(clientSocket, serverSocket);
+	}
+
+	private static String keyStore() {
+		String keyStore = System.getProperty("javax.net.ssl.keyStore");
+		if (keyStore == null) {
+			throw new IllegalStateException("Must provide key for SSL server.");
+		}
+		return keyStore;
+	}
+	private static String keyStoreType() {
+		return System.getProperty("javax.net.ssl.keyStoreType", KeyStore.getDefaultType());
+	}
+	private static String keyStoreProvider() {
+		return System.getProperty("javax.net.ssl.keyStoreProvider");
+	}
+	private static char[] keystorePassword() {
+		return System.getProperty("javax.net.ssl.keyStorePassword", "changeit").toCharArray();
+	}
+
+	private static KeyStore keyStoreInstance() throws KeyStoreException, NoSuchProviderException {
+		return keyStoreProvider() != null ?
+				  KeyStore.getInstance(keyStoreType(), keyStoreProvider())
+				: KeyStore.getInstance(keyStoreType());
+	}
+	
+    private static KeyManager[] getKeyManagers() throws Exception {
+        LOGGER.log(Level.CONFIG, "keyStore is : {0}", keyStore());
+        LOGGER.log(Level.CONFIG, "keyStore type is : {0}", keyStoreType());
+        LOGGER.log(Level.CONFIG, "keyStore provider is : {0}", keyStoreProvider());
+        // Don't log the password!
+
+        try (FileInputStream fs = new FileInputStream(keyStore())) {
+        	KeyStore ks = keyStoreInstance();
+        	ks.load(fs, keystorePassword());
+        	
+        	String defaultAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
+			LOGGER.log(Level.CONFIG, "Init keymanager of type {0}", defaultAlgorithm);
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(defaultAlgorithm);
+            kmf.init(ks, keystorePassword());
+            return kmf.getKeyManagers();
+        }
+    }
+    
+}


### PR DESCRIPTION
Needed this for docker. Eventually, we should force all relay connections through ssl. Need to make setting up the key/trust easier first though (I think).
