### PR TITLE
Honor java.net.ssl.trustStorePassword when opening truststore.jks.

### DIFF
--- a/src/main/java/com/moesol/jgit/HookedHttpClientConnectionFactory.java
+++ b/src/main/java/com/moesol/jgit/HookedHttpClientConnectionFactory.java
@@ -83,9 +83,13 @@ public class HookedHttpClientConnectionFactory extends HttpClientConnectionFacto
 			return null;
 		}
 		
+		char[] twp = System.getProperty("javax.net.ssl.trustStorePassword", "").toCharArray();
+		if (twp.length == 0) {
+			twp = null; // Backward compatible with prior version, which always used null.
+		}
 		try (FileInputStream trust = new FileInputStream(trustStoreFile)) {
 			KeyStore r = KeyStore.getInstance(KeyStore.getDefaultType());
-			r.load(trust, null);
+			r.load(trust, twp);
 			return r;
 		}
 	}


### PR DESCRIPTION
New keytool program forces a password on .jks files.
If you don't specify the system property you get the old behavior,
and it will open old jks files without a password. However,
without this commit, setting the password in a system property
was ignored.