### PR TITLE
Adding profile for building an RPM to simplify installation on RHEL/CentOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<build.number>0</build.number>
 	</properties>
 
 	<scm>
@@ -154,6 +155,66 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>rpm</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>rpm-maven-plugin</artifactId>
+						<version>2.2.0</version>
+						<executions>
+							<execution>
+								<id>attached-rpm</id>
+								<phase>package</phase>
+								<goals>
+									<goal>attached-rpm</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<name>${project.artifactId}</name>
+							<group>Applications</group>
+							<targetOS>Linux</targetOS>
+							<prefix>/usr/local</prefix>
+							<release>${build.number}</release>
+							<defaultDirmode>755</defaultDirmode>
+							<defaultFilemode>644</defaultFilemode>
+							<defaultUsername>root</defaultUsername>
+							<defaultGroupname>root</defaultGroupname>
+							<needarch>noarch</needarch>
+							<defineStatements>
+								<defineStatement>_unpackaged_files_terminate_build 0</defineStatement>
+								<defineStatement>__jar_repack 0</defineStatement>
+							</defineStatements>
+							<mappings>
+								<mapping>
+									<directory>/usr/local/bin</directory>
+									<sources>
+										<source>
+											<location>src/main/shell/cac-git</location>
+										</source>
+									</sources>
+									<filemode>755</filemode>
+								</mapping>
+								<mapping>
+									<directory>/usr/local/lib/cac-git</directory>
+									<sources>
+										<source>
+											<location>target/cac-aware-jgit-jar-with-dependencies.jar</location>
+										</source>
+									</sources>
+								</mapping>
+							</mappings>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+
 		</profile>
 	</profiles>
 </project>

--- a/src/main/shell/cac-git
+++ b/src/main/shell/cac-git
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ -n "${JAVA_HOME}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]];  then
+    JAVA="${JAVA_HOME}/bin/java"
+elif type -p java; then
+    JAVA=java
+else
+    echo "Error: JAVA_HOME is not set and java could not be found in PATH." 1>&2
+    exit 1
+fi
+
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  TARGET="$(readlink "$SOURCE")"
+  if [[ $SOURCE == /* ]]; then
+    SOURCE="$TARGET"
+  else
+    PROJECT_BIN_DIR="$( dirname "$SOURCE" )"
+    SOURCE="$PROJECT_BIN_DIR/$TARGET" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  fi
+done
+RDIR="$( dirname "$SOURCE" )"
+PROJECT_BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+PROJECT_DIR="$(dirname "$PROJECT_BIN_DIR")"
+
+${JAVA} -jar /usr/local/lib/cac-git/cac-aware-jgit-jar-with-dependencies.jar ${1+"$@"}


### PR DESCRIPTION
The RPM installs the uber-jar and a script into standard locations on linux that will typically be on the path thus avoiding several of the manual steps.

    mvn clean install -Prpm
    rpm -ivh target/rpm/cac-agent/RPMS/noarch/cac-agent-1.12-0.noarch.rpm

This does not attempt to create the `~/.moesol/cac-agent/pkcs11.config` at this time.