### PR TITLE
Switches to using maven toolchains.xml to locate JDK.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           when: always
       - store_test_results:
           path: ~/junit
-      - run: mvn -P circleci integration-test -DJDK_8_HOME="$JDK_8_HOME" -DJDK_11_HOME="$JDK_11_HOME"
+      - run: mvn -P circleci integration-test --global-toolchains .circleci/toolchains.xml
 
 
       - store_artifacts:

--- a/.circleci/toolchains.xml
+++ b/.circleci/toolchains.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+  <!-- JDK toolchains -->
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>8</version>
+      <vendor>openjdk</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/java-se-8u40-ri/</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>11</version>
+      <vendor>openjdk</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/usr/lib/jvm/java-11-openjdk-amd64/</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .settings
 .metadata
 _book
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .metadata
 _book
 .vscode/
+certs/

--- a/Building-cac-agent.md
+++ b/Building-cac-agent.md
@@ -8,33 +8,35 @@ To build cac-agent, you must have JDK8 and JDK11 available for compiling.
 This allows cac-agent to carry libraries that work with both runtime
 environments.
 
-You can specify the paths to these via `~/.m2/settings.xml`:
+The version of `java` and `javac` in your default path can be any version 8 or greater.
 
-	<settings>
-	  ...
-	  <profiles>
-	    <profile>
-	      <id>cac-agent-variables</id>
-	      <!-- Point to your JDK locations -->
-	      <properties>
-		<JDK_8_HOME>/usr/lib/jvm/java-8-openjdk-amd64</JDK_8_HOME>
-		<JDK_11_HOME>/usr/lib/jvm/java-11-openjdk-amd64</JDK_11_HOME>
-	      </properties>
-	    </profile>
-	  </profiles>
-	  ...
-	 
-	  <!-- Activate profile by default (for convenience) -->
-	  <activeProfiles>
-	    <activeProfile>cac-agent-variables</activeProfile>
-	  </activeProfiles>
-	</settings>
+## Using maven tool chains to define required jdk locations
 
-... or at the time building (via command line args):
+You can specify the paths to JDK8 and JDK11 via `~/.m2/toolchains.xml`:
 
-	mvn ... -DJDK_8_HOME=/usr/lib/jvm/java-8-openjdk-amd64 -DJDK_11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-
-The version of `java` and `javac` in you default path can be any version 8 or greater.
+	<?xml version="1.0" encoding="UTF8"?>
+	<toolchains>
+		<toolchain>
+			<type>jdk</type>
+			<provides>
+				<version>8</version>
+				<vendor>openjdk</vendor>
+			</provides>
+			<configuration>
+				<jdkHome>/usr/lib/jvm/java-8-openjdk-amd64/</jdkHome>
+			</configuration>
+		</toolchain>
+		<toolchain>
+			<type>jdk</type>
+			<provides>
+				<version>11</version>
+				<vendor>openjdk</vendor>
+			</provides>
+			<configuration>
+				<jdkHome>/usr/lib/jvm/java-11-openjdk-amd64/</jdkHome>
+			</configuration>
+		</toolchain>
+	</toolchains>
 
 
 Building

--- a/cac-agent-jdk-11/pom.xml
+++ b/cac-agent-jdk-11/pom.xml
@@ -28,11 +28,21 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
+				<artifactId>maven-toolchains-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>toolchain</goal>
+						</goals>
+					</execution>
+				</executions>
 				<configuration>
-					<verbose>true</verbose>
-					<fork>true</fork>
-					<executable>${JDK_11_HOME}/bin/javac</executable>
+					<toolchains>
+						<jdk>
+							<version>11</version>
+							<vendor>openjdk</vendor>
+						</jdk>
+					</toolchains>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/cac-agent-jdk-8/pom.xml
+++ b/cac-agent-jdk-8/pom.xml
@@ -28,12 +28,21 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
+				<artifactId>maven-toolchains-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>toolchain</goal>
+						</goals>
+					</execution>
+				</executions>
 				<configuration>
-					<verbose>true</verbose>
-					<fork>true</fork>
-					<executable>${JDK_8_HOME}/bin/javac</executable>
-					<compilerVersion>1.8</compilerVersion>
+					<toolchains>
+						<jdk>
+							<version>8</version>
+							<vendor>openjdk</vendor>
+						</jdk>
+					</toolchains>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.MoebiusSolutions</groupId>
 	<artifactId>cac-agent-parent</artifactId>
@@ -15,15 +16,9 @@
 		<build.number>0</build.number>
 
 		<!--
-			You must specify JDK 8 and 11 binaries paths to build. For example, 
-			this would work from the command line:
-			mvn clean install -DJDK_8_HOME=/usr/lib/jvm/java-8-openjdk-amd64 -DJDK_11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+			You must specify JDK 8 and 11 binaries paths to build in ~/.m2/toolchains.xml
 		-->
-		<!--
-		<JDK_8_HOME>/usr/lib/jvm/java-8-openjdk-amd64</JDK_8_HOME>
-		<JDK_11_HOME>/usr/lib/jvm/java-11-openjdk-amd64</JDK_11_HOME>
-		-->
-		
+
 		<!--
 			The server entry in settings.xml containing the credentials 
 			to use with when pushing maven artifacts to github
@@ -50,7 +45,7 @@
 		
 			By letting maven deploy here, we can follow-up with the github plugin
 			to upload the artifacts. (GitHub doens't support the Maven deploy protocol.)
-		 --> 
+		 -->
 		<repository>
 			<id>internal.repo</id>
 			<name>Temporary Staging Repository</name>
@@ -86,12 +81,42 @@
 	</dependencyManagement>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-toolchains-plugin</artifactId>
+					<version>1.1</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<artifactId>maven-toolchains-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>toolchain</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<!-- default toolchain unless overriden -->
+					<toolchains>
+						<jdk>
+							<version>8</version>
+							<vendor>openjdk</vendor>
+						</jdk>
+					</toolchains>
+				</configuration>
 			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Opens the way to setting up profiles that only
build java8 or java11.