### PR TITLE
Only display certificates that match the list of acceptable issuers

### DIFF
--- a/cac-agent/src/main/java/com/moesol/cac/agent/Config.java
+++ b/cac-agent/src/main/java/com/moesol/cac/agent/Config.java
@@ -17,6 +17,7 @@ public class Config {
 	private static final String AGENT_PROPERTIES = "agent.properties";
 
 	private boolean useWindowsTrust = true;
+	private boolean checkCertIssuer = true;
 	private String defaultCertificateName = null;
 	private boolean tty = false;
 	private String user = null;
@@ -39,6 +40,14 @@ public class Config {
 
 	public void setUseWindowsTrust(boolean useWindowsTrust) {
 		this.useWindowsTrust = useWindowsTrust;
+	}
+
+	public boolean isCheckCertIssuer() {
+		return checkCertIssuer;
+	}
+
+	public void setCheckCertIssuer(boolean checkCertIssuer) {
+		this.checkCertIssuer = checkCertIssuer;
 	}
 
 	public String getDefaultCertificateName() {
@@ -129,6 +138,7 @@ public class Config {
 			Config result = new Config();
 			result.setDefaultCertificateName(p.getProperty("default.cert.name"));
 			result.setUseWindowsTrust(Boolean.parseBoolean(p.getProperty("use.windows.trust", "true")));
+			result.setCheckCertIssuer(Boolean.parseBoolean(p.getProperty("check.cert.issuer", "true")));
 			result.setTty(Boolean.parseBoolean(p.getProperty("use.tty")));
 			result.setUser(p.getProperty("user"));
 			result.setPass(p.getProperty("pass"));


### PR DESCRIPTION
During TLS handshake, the server may provide a list of acceptable issuers. If so, filter the list of known certificates so we only ask the user to choose ones that will be acceptable to the server.

According to Oracle [source docs](https://code.yawk.at/java/13/java.base/sun/security/ssl/X509KeyManagerImpl.java#694), non-matching certificates will "almost certainly be rejected by the peer." Nevertheless, users can still disable this filtering check by adding a line to their `agent.properties` file:

    check.cert.issuer: false
