### PR TITLE
Only display certificates that have an appropriate key usage

### DIFF
--- a/cac-agent/src/main/java/com/moesol/cac/agent/Config.java
+++ b/cac-agent/src/main/java/com/moesol/cac/agent/Config.java
@@ -18,6 +18,7 @@ public class Config {
 
 	private boolean useWindowsTrust = true;
 	private boolean checkCertIssuer = true;
+	private boolean checkKeyUsage = true;
 	private String defaultCertificateName = null;
 	private boolean tty = false;
 	private String user = null;
@@ -48,6 +49,14 @@ public class Config {
 
 	public void setCheckCertIssuer(boolean checkCertIssuer) {
 		this.checkCertIssuer = checkCertIssuer;
+	}
+
+	public boolean isCheckKeyUsage() {
+		return checkKeyUsage;
+	}
+
+	public void setCheckKeyUsage(boolean checkKeyUsage) {
+		this.checkKeyUsage = checkKeyUsage;
 	}
 
 	public String getDefaultCertificateName() {
@@ -139,6 +148,7 @@ public class Config {
 			result.setDefaultCertificateName(p.getProperty("default.cert.name"));
 			result.setUseWindowsTrust(Boolean.parseBoolean(p.getProperty("use.windows.trust", "true")));
 			result.setCheckCertIssuer(Boolean.parseBoolean(p.getProperty("check.cert.issuer", "true")));
+			result.setCheckKeyUsage(Boolean.parseBoolean(p.getProperty("check.key.usage", "true")));
 			result.setTty(Boolean.parseBoolean(p.getProperty("use.tty")));
 			result.setUser(p.getProperty("user"));
 			result.setPass(p.getProperty("pass"));


### PR DESCRIPTION
In `X509KeyManager` implementations, the `chooseClientAlias` method returns the alias of a user certificate that should be used for TLS client authentication. The changes in this pull request filter the full list of known certificates, so we only ask the user to choose ones whose key usage fields actually allow TLS client authentication. 

This behavior aligns with that of mainstream web browsers: if you visit a website that requires a CAC, your browser will only display certificates that are meant for client auth. (It won't display certificates for secure email, encryption/decryption, etc.) If you don't have a client auth certificate, the web browser won't display any certificate prompt at all; you'll just receive a permission denied error from the server.

However, the source code in OpenJDK is a bit more lenient. It prefers a certificate with correct key usage fields, but will fall back to lesser certificates if one isn't present.

This change aligns the default behavior or cac-agent with that of mainstream browsers. Users who need the more lenient matching can add the following line to their `agent.properties` file:

    check.key.usage: false

The logic for checking key usage is fairly tricky/non-obvious. The code in this change was patterned after the algorithms in OpenJDK, in the [sun.security.ssl.X509KeyManagerImpl](https://code.yawk.at/java/13/java.base/sun/security/ssl/X509KeyManagerImpl.java#514) class. To avoid copyright claims, that code was not copied verbatim; but reviewers can compare the underlying logic in this pull request against the OpenJDK logic to check correctness.