### PR TITLE
Tweak pom to address floorMod-style issue

### DIFF
--- a/cac-agent/pom.xml
+++ b/cac-agent/pom.xml
@@ -41,8 +41,9 @@
 							<goal>compile</goal>
 						</goals>
 						<configuration>
-							<source>1.8</source>
-							<target>1.8</target>
+							<release>8</release>
+							<source>8</source>
+							<target>8</target>
 						</configuration>
 					</execution>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 		<build.number>0</build.number>
 
 		<!--


### PR DESCRIPTION
Tweak cac-agent pom to address floorMod-style issue 
Tweak root pom, replacing jdk 1.8 with 8 for consistency.

`<release>8</release>` technique described here:
https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html

Interestingly, while the page describes using 3.13.0, the technique works fine with 3.12.1.